### PR TITLE
Changing group id

### DIFF
--- a/components/org.wso2.carbon.identity.provisioning.connector.spml/pom.xml
+++ b/components/org.wso2.carbon.identity.provisioning.connector.spml/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <groupId>org.wso2.carbon.identity</groupId>
+        <groupId>org.wso2.carbon.identity.outbound.provisioning.spml</groupId>
         <artifactId>identity-outbound-provisioning-spml</artifactId>
         <relativePath>../../pom.xml</relativePath>
         <version>5.1.2-SNAPSHOT</version>
@@ -55,11 +55,11 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.provisioning</artifactId>
         </dependency>
         <dependency>

--- a/features/org.wso2.carbon.identity.provisioning.connector.spml.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.provisioning.connector.spml.server.feature/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.wso2.carbon.identity</groupId>
+        <groupId>org.wso2.carbon.identity.outbound.provisioning.spml</groupId>
         <artifactId>identity-outbound-provisioning-spml</artifactId>
         <relativePath>../../pom.xml</relativePath>
         <version>5.1.2-SNAPSHOT</version>
@@ -34,7 +34,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
+            <groupId>org.wso2.carbon.identity.outbound.provisioning.spml</groupId>
             <artifactId>org.wso2.carbon.identity.provisioning.connector.spml</artifactId>
         </dependency>
     </dependencies>
@@ -57,7 +57,7 @@
                             <propertiesFile>../etc/feature.properties</propertiesFile>
                             <bundles>
                                 <bundleDef>
-                                    org.wso2.carbon.identity:org.wso2.carbon.identity.provisioning.connector.spml
+                                    org.wso2.carbon.identity.outbound.provisioning.spml:org.wso2.carbon.identity.provisioning.connector.spml
                                 </bundleDef>
                             </bundles>
                             <importFeatures>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <version>1</version>
     </parent>
 
-    <groupId>org.wso2.carbon.identity</groupId>
+    <groupId>org.wso2.carbon.identity.outbound.provisioning.spml</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>identity-outbound-provisioning-spml</artifactId>
     <version>5.1.2-SNAPSHOT</version>
@@ -60,18 +60,18 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity</groupId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity</groupId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.provisioning</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wso2.carbon.identity</groupId>
+                <groupId>org.wso2.carbon.identity.outbound.provisioning.spml</groupId>
                 <artifactId>org.wso2.carbon.identity.provisioning.connector.spml</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
     <properties>
         <carbon.kernel.version>4.4.7</carbon.kernel.version>
 
-        <carbon.identity.framework.version>5.2.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.5.0-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.outbound.prov.spml.package.export.version>${project.version}
         </carbon.identity.outbound.prov.spml.package.export.version>
 


### PR DESCRIPTION
Changing group id from `org.wso2.carbon.identity` to `org.wso2.carbon.identity.outbound.provisioning.spml`
